### PR TITLE
update node image version to 20.7.0

### DIFF
--- a/api/Dockerfile.api
+++ b/api/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:17.2.0
+FROM node:20.7.0
 
 WORKDIR /api
 COPY . /api


### PR DESCRIPTION
vm build image 時要求 node version 要是 v14 || v16 || >v18